### PR TITLE
fix: add required permissions for version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -9,6 +9,9 @@ jobs:
   version-bump:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Fixes the 403 permission denied error that occurred when the version-bump workflow tried to push commits and tags to the repository.

## Problem
The GitHub Actions workflow failed with:
```
remote: Permission to malinmalliyawadu/volunteer-portal.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/malinmalliyawadu/volunteer-portal/': The requested URL returned error: 403
```

## Solution
Added explicit permissions to the workflow job:
- `contents: write` - Required for pushing commits and creating tags
- `pull-requests: read` - Required for reading PR labels

## Type of Change
- 🐛 Bug fix (fixes GitHub Actions permission issue)

## Testing
- [x] Workflow permissions validated
- [ ] Will be tested when this PR is merged (should trigger successful version bump)

🤖 Generated with [Claude Code](https://claude.ai/code)