### PR TITLE
fix: use deploy key for version-bump workflow to bypass branch protection

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: read
+      pull-requests: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -163,6 +163,7 @@ jobs:
       - name: Push changes
         if: steps.version-type.outputs.bump_type != 'skip'
         run: |
+          git remote set-url origin git@github.com:malinmalliyawadu/volunteer-portal.git
           git push origin main "v${{ steps.bump-version.outputs.new_version }}"
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
Updates the version-bump workflow to use SSH deploy key authentication instead of GITHUB_TOKEN to bypass branch protection rules.

## Problem
The version-bump workflow failed with repository rule violations:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
```

Branch protection rules prevent direct pushes to main, but the workflow needs to push version bump commits and tags.

## Solution
- Replace `token: ${{ secrets.GITHUB_TOKEN }}` with `ssh-key: ${{ secrets.DEPLOY_KEY }}`
- Set Git remote URL to SSH format for authenticated pushing
- Deploy keys can be configured to bypass branch protection rules

## Setup Required
After merging this PR, you need to:

1. **Add Deploy Key to Repository**:
   - Go to Settings → Deploy keys → Add deploy key
   - Title: `GitHub Actions Version Bump`
   - Key: The public key that was generated
   - ✅ Enable "Allow write access"

2. **Add Private Key to Secrets**:
   - Go to Settings → Secrets and variables → Actions
   - Name: `DEPLOY_KEY`
   - Value: The private key that was generated

## Type of Change
- 🐛 Bug fix (fixes workflow authentication issue)

## Testing
- [x] Workflow syntax validated
- [ ] Will be tested when next version bump occurs

🤖 Generated with [Claude Code](https://claude.ai/code)