### PR TITLE
fix: add SSH agent setup for proper deploy key loading

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -14,6 +14,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Setup SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
Adds SSH agent setup to properly load the deploy key in the version-bump workflow.

## Problem
The workflow failed with SSH key loading errors:
```
Load key "/home/runner/work/_temp/44fb758f-ef91-4ba3-894d-aed32fe41752": error in libcrypto
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

## Root Cause
The `actions/checkout` action alone isn't sufficient to load SSH keys properly. The SSH key needs to be loaded into the SSH agent first.

## Solution
- Add `webfactory/ssh-agent@v0.9.0` action before checkout
- This properly loads the private key into the SSH agent
- Allows subsequent Git operations to authenticate correctly

## Type of Change
- 🐛 Bug fix (fixes SSH authentication in workflow)

## Testing
- [x] Workflow syntax validated
- [ ] Will be tested when this PR is merged (should trigger successful version bump)

## References
- [webfactory/ssh-agent documentation](https://github.com/webfactory/ssh-agent)

🤖 Generated with [Claude Code](https://claude.ai/code)