### PR TITLE
feat: add volunteer attendance tracking for past shifts

### DIFF
--- a/web/src/app/admin/shifts/page.tsx
+++ b/web/src/app/admin/shifts/page.tsx
@@ -58,7 +58,7 @@ export default async function AdminShiftsPage({
       signups: {
         where: {
           status: {
-            in: ["CONFIRMED", "PENDING", "WAITLISTED", "REGULAR_PENDING"],
+            in: ["CONFIRMED", "PENDING", "WAITLISTED", "REGULAR_PENDING", "NO_SHOW"],
           },
         },
         include: {
@@ -100,7 +100,7 @@ export default async function AdminShiftsPage({
           signups: {
             where: {
               status: {
-                in: ["CONFIRMED", "PENDING", "WAITLISTED", "REGULAR_PENDING"],
+                in: ["CONFIRMED", "PENDING", "WAITLISTED", "REGULAR_PENDING", "NO_SHOW"],
               },
             },
           },
@@ -129,10 +129,14 @@ export default async function AdminShiftsPage({
       );
 
   // Get shift data for the calendar with location, capacity, and confirmed counts
+  // Include past shifts for attendance tracking - show last 30 days + future shifts
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  
   const allCalendarShifts = await prisma.shift.findMany({
     where: {
       start: {
-        gte: new Date(),
+        gte: thirtyDaysAgo,
       },
     },
     select: {

--- a/web/src/components/animated-shift-cards.tsx
+++ b/web/src/components/animated-shift-cards.tsx
@@ -70,6 +70,7 @@ import {
   Edit,
   Trash2,
   Info,
+  UserX,
 } from "lucide-react";
 import { VolunteerActions } from "@/components/volunteer-actions";
 import { getShiftTheme } from "@/lib/shift-themes";
@@ -181,6 +182,9 @@ export function AnimatedShiftCards({ shifts }: AnimatedShiftCardsProps) {
           ).length;
           const waitlisted = shift.signups.filter(
             (s) => s.status === "WAITLISTED"
+          ).length;
+          const noShow = shift.signups.filter(
+            (s) => s.status === "NO_SHOW"
           ).length;
           const staffingStatus = getStaffingStatus(confirmed, shift.capacity);
 
@@ -307,6 +311,15 @@ export function AnimatedShiftCards({ shifts }: AnimatedShiftCardsProps) {
                         >
                           <Users className="h-3 w-3" />
                           {waitlisted} waitlisted
+                        </div>
+                      )}
+                      {noShow > 0 && (
+                        <div
+                          data-testid={`no-show-badge-${shift.id}`}
+                          className="flex items-center gap-1 px-2 py-1 bg-red-100 text-red-700 rounded text-xs font-medium"
+                        >
+                          <UserX className="h-3 w-3" />
+                          {noShow} no show
                         </div>
                       )}
                     </div>

--- a/web/src/components/shift-calendar.tsx
+++ b/web/src/components/shift-calendar.tsx
@@ -68,7 +68,7 @@ export function ShiftCalendar({
   };
 
   const handleDateSelect = (date: Date | undefined) => {
-    if (date && hasShifts(date)) {
+    if (date) {
       onDateSelect(date);
       setIsOpen(false);
     }
@@ -125,7 +125,6 @@ export function ShiftCalendar({
             mode="single"
             selected={selectedDate}
             onSelect={handleDateSelect}
-            disabled={(date) => !hasShifts(date)}
             modifiers={{
               hasShifts: (date) => hasShifts(date),
               selected: (date) => isSameDay(date, selectedDate),


### PR DESCRIPTION
## Summary
- Implement attendance tracking system allowing admins to mark volunteers as present or no-show for completed shifts
- Enable calendar navigation to past shifts (last 30 days) for attendance management
- Add visual indicators and smart UI controls for attendance status

## Changes Made

### API Enhancements
- Extended `/api/admin/signups/[id]` with `mark_absent` and `mark_present` actions
- Added validation to ensure attendance can only be marked for completed shifts
- Proper error handling and status transitions between CONFIRMED ↔ NO_SHOW

### Admin UI Improvements
- **Past Shift Controls**: For completed shifts, show "Attended" status with option to mark as "No Show"
- **No-Show Management**: Allow reverting no-show status back to "Present" 
- **Smart UI**: Only show attendance controls for past shifts, preserve existing functionality for future shifts
- **Visual Indicators**: Added red "X no show" badges in shift summaries to highlight attendance issues

### Calendar Access
- Extended shift data query to include last 30 days (previously future-only)
- Removed date selection restrictions to allow navigation to any date
- Calendar now shows historical shifts with proper staffing indicators

### Database Integration
- Leverages existing `NO_SHOW` status in `SignupStatus` enum
- Updated admin shift queries to include NO_SHOW signups in display
- No schema changes required - uses existing infrastructure

## Test Plan
- [x] Navigate to past dates in admin shifts calendar
- [x] Mark confirmed volunteers as no-show for completed shifts
- [x] Revert no-show status back to present
- [x] Verify future shift functionality remains unchanged
- [x] Check visual indicators appear correctly in shift summaries
- [x] Test API validation prevents marking attendance for future shifts

🤖 Generated with [Claude Code](https://claude.ai/code)